### PR TITLE
feat: add realization act nav and mobile-friendly report_olap

### DIFF
--- a/admin/app/[locale]/admin/sales-plans/[id]/edit/page.tsx
+++ b/admin/app/[locale]/admin/sales-plans/[id]/edit/page.tsx
@@ -131,35 +131,25 @@ export default function EditSalesPlanPage() {
         </div>
 
         {items.length > 0 && (
-          <div className="rounded-md border">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b bg-muted/50">
-                  <th className="p-3 text-left font-medium">Продукт</th>
-                  <th className="p-3 text-center font-medium w-40">План на месяц</th>
-                  <th className="p-3 text-right font-medium w-20"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((item) => (
-                  <tr key={item.product_id} className="border-b">
-                    <td className="p-3">{item.product_name}</td>
-                    <td className="p-3">
-                      <Input
-                        type="number"
-                        min={0}
-                        value={item.planned_qty || ""}
-                        onChange={(e) => updateQty(item.product_id, Number(e.target.value))}
-                        className="text-center"
-                      />
-                    </td>
-                    <td className="p-3 text-right">
-                      <Button variant="ghost" size="sm" onClick={() => removeProduct(item.product_id)}>✕</Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="space-y-3">
+            {items.map((item) => (
+              <div key={item.product_id} className="rounded-xl border bg-card p-3 shadow-sm">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium flex-1 mr-2">{item.product_name}</span>
+                  <Button variant="ghost" size="sm" onClick={() => removeProduct(item.product_id)}>✕</Button>
+                </div>
+                <div className="flex items-center gap-2">
+                  <label className="text-sm text-muted-foreground whitespace-nowrap">План/мес:</label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={item.planned_qty || ""}
+                    onChange={(e) => updateQty(item.product_id, Number(e.target.value))}
+                    className="text-center"
+                  />
+                </div>
+              </div>
+            ))}
           </div>
         )}
 

--- a/admin/app/[locale]/admin/sales-plans/create/page.tsx
+++ b/admin/app/[locale]/admin/sales-plans/create/page.tsx
@@ -125,11 +125,11 @@ export default function CreateSalesPlanPage() {
       <h2 className="text-3xl font-bold tracking-tight pb-4">Создать план продаж</h2>
 
       <div className="space-y-6">
-        <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-4">
           <div>
             <label className="text-sm font-medium mb-1 block">Терминал</label>
             <Select value={terminalId} onValueChange={setTerminalId}>
-              <SelectTrigger><SelectValue placeholder="Выберите терминал" /></SelectTrigger>
+              <SelectTrigger className="w-full"><SelectValue placeholder="Выберите терминал" /></SelectTrigger>
               <SelectContent>
                 {terminals.map((t: any) => (
                   <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
@@ -137,27 +137,29 @@ export default function CreateSalesPlanPage() {
               </SelectContent>
             </Select>
           </div>
-          <div>
-            <label className="text-sm font-medium mb-1 block">Год</label>
-            <Select value={year} onValueChange={setYear}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="2025">2025</SelectItem>
-                <SelectItem value="2026">2026</SelectItem>
-                <SelectItem value="2027">2027</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <label className="text-sm font-medium mb-1 block">Месяц</label>
-            <Select value={month} onValueChange={setMonth}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {MONTHS.map((name, i) => (
-                  <SelectItem key={i + 1} value={String(i + 1)}>{name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-sm font-medium mb-1 block">Год</label>
+              <Select value={year} onValueChange={setYear}>
+                <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="2025">2025</SelectItem>
+                  <SelectItem value="2026">2026</SelectItem>
+                  <SelectItem value="2027">2027</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium mb-1 block">Месяц</label>
+              <Select value={month} onValueChange={setMonth}>
+                <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {MONTHS.map((name, i) => (
+                    <SelectItem key={i + 1} value={String(i + 1)}>{name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         </div>
 
@@ -184,35 +186,25 @@ export default function CreateSalesPlanPage() {
         </div>
 
         {items.length > 0 && (
-          <div className="rounded-md border">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b bg-muted/50">
-                  <th className="p-3 text-left font-medium">Продукт</th>
-                  <th className="p-3 text-center font-medium w-40">План на месяц</th>
-                  <th className="p-3 text-right font-medium w-20"></th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((item) => (
-                  <tr key={item.product_id} className="border-b">
-                    <td className="p-3">{item.product_name}</td>
-                    <td className="p-3">
-                      <Input
-                        type="number"
-                        min={0}
-                        value={item.planned_qty || ""}
-                        onChange={(e) => updateQty(item.product_id, Number(e.target.value))}
-                        className="text-center"
-                      />
-                    </td>
-                    <td className="p-3 text-right">
-                      <Button variant="ghost" size="sm" onClick={() => removeProduct(item.product_id)}>✕</Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="space-y-3">
+            {items.map((item) => (
+              <div key={item.product_id} className="rounded-xl border bg-card p-3 shadow-sm">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium flex-1 mr-2">{item.product_name}</span>
+                  <Button variant="ghost" size="sm" onClick={() => removeProduct(item.product_id)}>✕</Button>
+                </div>
+                <div className="flex items-center gap-2">
+                  <label className="text-sm text-muted-foreground whitespace-nowrap">План/мес:</label>
+                  <Input
+                    type="number"
+                    min={0}
+                    value={item.planned_qty || ""}
+                    onChange={(e) => updateQty(item.product_id, Number(e.target.value))}
+                    className="text-center"
+                  />
+                </div>
+              </div>
+            ))}
           </div>
         )}
 

--- a/admin/app/[locale]/report_olap/data-table.tsx
+++ b/admin/app/[locale]/report_olap/data-table.tsx
@@ -238,8 +238,8 @@ export function DataTable<TData, TValue>() {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-md border relative ">
-        <Table>
+      <div className="rounded-md border relative overflow-x-auto -mx-4 sm:mx-0">
+        <Table className="min-w-[600px]">
           <TableHeader className="bg-slate-600 dark:bg-slate-100 z-50 sticky top-0">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
@@ -333,11 +333,10 @@ export function DataTable<TData, TValue>() {
         </Table>
       </div>
       {/* <div className="h-2" /> */}
-      <div className="flex h-24 items-center justify-between pb-4 px-2">
-        <div className="flex-1 text-sm text-muted-foreground"></div>
-        <div className="flex items-center space-x-6 lg:space-x-8">
+      <div className="flex flex-wrap gap-3 items-center justify-between pb-4 px-2 py-4">
+        <div className="flex items-center gap-2">
           <div className="flex items-center space-x-2">
-            <p className="text-sm font-medium">Rows per page</p>
+            <p className="text-sm font-medium whitespace-nowrap">Rows per page</p>
             <Select
               value={`${table.getState().pagination.pageSize}`}
               onValueChange={(value) => {
@@ -359,7 +358,7 @@ export function DataTable<TData, TValue>() {
             </Select>
           </div>
         </div>
-        <div className="flex w-[100px] items-center justify-center text-sm font-medium">
+        <div className="flex items-center justify-center text-sm font-medium whitespace-nowrap">
           Page {table.getState().pagination.pageIndex + 1} of{" "}
           {table.getPageCount()}
         </div>

--- a/admin/app/[locale]/report_olap/olap_filters.tsx
+++ b/admin/app/[locale]/report_olap/olap_filters.tsx
@@ -72,7 +72,7 @@ export const OlapFilters = () => {
             id="date"
             variant={"outline"}
             className={cn(
-              "w-[300px] justify-start text-left font-normal",
+              "w-full sm:w-[300px] justify-start text-left font-normal",
               !date && "text-muted-foreground"
             )}
           >
@@ -158,7 +158,7 @@ export const OlapFilters = () => {
           setStoreId(value);
         }}
       >
-        <SelectTrigger className="max-w-xs">
+        <SelectTrigger className="w-full sm:max-w-xs">
           <SelectValue placeholder="Склады" />
         </SelectTrigger>
         <SelectContent>

--- a/admin/app/[locale]/report_olap/page.tsx
+++ b/admin/app/[locale]/report_olap/page.tsx
@@ -6,15 +6,15 @@ import Back from "../manager_reports/Back";
 
 export default function ReportsListPage() {
   return (
-    <div>
+    <div className="w-full overflow-hidden">
       <Back />
       <div className="flex justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">
+        <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">
           Акт Реализации
         </h2>
       </div>
       <OlapFilters />
-      <div className="py-10">
+      <div className="py-4 sm:py-10">
         <DataTable />
       </div>
     </div>

--- a/admin/components/layout/sales-plan-layout.tsx
+++ b/admin/components/layout/sales-plan-layout.tsx
@@ -54,6 +54,26 @@ export default function SalesPlanLayout({
       ),
     },
     {
+      href: "/report_olap",
+      label: "Акт Реализации",
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="w-6 h-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"
+          />
+        </svg>
+      ),
+    },
+    {
       href: "/admin/sales-plans/create",
       label: "Создать",
       icon: (


### PR DESCRIPTION
## Summary
- Add "Акт Реализации" navigation item to sales plan bottom nav bar
- Make report_olap page responsive for mobile devices (filters, table scroll, pagination)

## Test plan
- [x] Verified bottom nav shows 4 items on mobile
- [x] Verified table has horizontal scroll on small screens
- [x] Verified filters stretch full width on mobile