### PR TITLE
fix: constrain pinned column width on mobile report_olap

### DIFF
--- a/admin/app/[locale]/report_olap/data-table.tsx
+++ b/admin/app/[locale]/report_olap/data-table.tsx
@@ -65,6 +65,8 @@ const getCommonPinningStyles = (column: Column<any>): CSSProperties => {
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     position: isPinned ? "sticky" : "relative",
     width: column.getSize(),
+    minWidth: isPinned ? column.getSize() : undefined,
+    maxWidth: isPinned ? column.getSize() : undefined,
     zIndex: isPinned ? 1 : 0,
   };
 };
@@ -151,6 +153,7 @@ export function DataTable<TData, TValue>() {
         accessorKey: "name",
         header: "Название",
         enablePinning: true,
+        size: 120,
       },
       {
         accessorKey: "supplierProductArticle",


### PR DESCRIPTION
## Summary
- Fix pinned "Название" column stretching to full viewport width on mobile
- Set minWidth/maxWidth on pinned columns so other data columns (Всего, dates) are visible
- Set column size to 120px for the name column

## Test plan
- [x] Verified columns Артикул and Единица измерения are now visible on mobile
- [x] Table scrolls horizontally to show date columns