### PR TITLE
fix: truncate names and clean up report_olap layout

### DIFF
--- a/admin/app/[locale]/report_olap/data-table.tsx
+++ b/admin/app/[locale]/report_olap/data-table.tsx
@@ -68,6 +68,9 @@ const getCommonPinningStyles = (column: Column<any>): CSSProperties => {
     width: column.getSize(),
     minWidth: isPinned ? column.getSize() : undefined,
     maxWidth: isPinned ? column.getSize() : undefined,
+    overflow: isPinned ? "hidden" : undefined,
+    textOverflow: isPinned ? "ellipsis" : undefined,
+    whiteSpace: isPinned ? "nowrap" : undefined,
     zIndex: isPinned ? 1 : 0,
   };
 };

--- a/admin/app/[locale]/report_olap/page.tsx
+++ b/admin/app/[locale]/report_olap/page.tsx
@@ -2,12 +2,10 @@
 import React, { useState } from "react";
 import { DataTable } from "./data-table";
 import { OlapFilters } from "./olap_filters";
-import Back from "../manager_reports/Back";
 
 export default function ReportsListPage() {
   return (
     <div className="w-full overflow-hidden">
-      <Back />
       <div className="flex justify-between">
         <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">
           Акт Реализации


### PR DESCRIPTION
Truncate long product names, remove unused Back button