### PR TITLE
fix: add DISH type to iiko olap sync and fix filter values

### DIFF
--- a/admin/app/[locale]/report_olap/olap_filters.tsx
+++ b/admin/app/[locale]/report_olap/olap_filters.tsx
@@ -185,11 +185,9 @@ export const OlapFilters = () => {
         <SelectContent>
           <SelectGroup>
             <SelectItem value="all">Все типы</SelectItem>
-            <SelectItem value="Goods">Товары</SelectItem>
-            <SelectItem value="Dish">Блюда</SelectItem>
-            <SelectItem value="Modifier">Модификаторы</SelectItem>
-            <SelectItem value="Outer">Внешние</SelectItem>
-            <SelectItem value="PreparedDish">Заготовки</SelectItem>
+            <SelectItem value="GOODS">Товары</SelectItem>
+            <SelectItem value="DISH">Блюда</SelectItem>
+            <SelectItem value="PREPARED">Заготовки</SelectItem>
           </SelectGroup>
         </SelectContent>
       </Select>

--- a/cron/iiko_sync.ts
+++ b/cron/iiko_sync.ts
@@ -472,7 +472,7 @@ export class IikoDictionariesService {
             },
             "Product.Type": {
               filterType: "IncludeValues",
-              values: ["GOODS", "PREPARED"],
+              values: ["GOODS", "PREPARED", "DISH"],
             },
           },
         }),


### PR DESCRIPTION
## Summary
- Add "DISH" to Product.Type filter in cron/iiko_sync.ts so dishes are fetched from iiko
- Fix frontend filter dropdown values to match actual DB values (GOODS, DISH, PREPARED uppercase)