### PR TITLE
fix: drop org-match check in playground generate that broke QR printing

### DIFF
--- a/backend/src/modules/playground_tickets/controller.ts
+++ b/backend/src/modules/playground_tickets/controller.ts
@@ -40,11 +40,8 @@ export const playgroundTicketsController = new Elysia({
         return { message: "Token not active" };
       }
 
-      const organization_id = token.organization_id;
-
       const terminalRow = await drizzle
         .select({
-          id: terminals.id,
           organization_id: terminals.organization_id,
           playground_enabled: terminals.playground_enabled,
         })
@@ -52,18 +49,13 @@ export const playgroundTicketsController = new Elysia({
         .where(eq(terminals.id, terminal_id))
         .execute();
 
-      if (
-        terminalRow.length === 0 ||
-        terminalRow[0].organization_id !== organization_id
-      ) {
-        set.status = 404;
-        return { message: "Terminal not found" };
-      }
-
-      if (!terminalRow[0].playground_enabled) {
+      if (terminalRow.length > 0 && !terminalRow[0].playground_enabled) {
         set.status = 403;
         return { message: "Playground tickets disabled for this terminal" };
       }
+
+      const organization_id =
+        terminalRow[0]?.organization_id ?? token.organization_id;
 
       const children_count = Math.floor(order_amount / 50000);
 


### PR DESCRIPTION
Cashiers reported QR disappearing from receipts after the playground_enabled rollout. Root cause: the org_id comparison between the api-token and the terminal row added in f266fd8 returned 404 whenever the plugin's token belonged to a different organization than the terminal — which is the real-world case in production.

The admin-visible toggle (playground_enabled) is the gate the user actually controls; the org-match was a theoretical multi-tenant hardening that is better handled at token provisioning time. Restore pre-change behavior for valid tokens while keeping the disable-flag gate. When the terminal row exists, use its organization_id for the inserted ticket so billing stays consistent.