### PR TITLE
fix: make playground tickets list responsive and harden bottom nav

### DIFF
--- a/admin/app/[locale]/admin/playground/list/data-table.tsx
+++ b/admin/app/[locale]/admin/playground/list/data-table.tsx
@@ -115,28 +115,34 @@ export function DataTable() {
           {tickets.map((ticket) => (
             <div
               key={ticket.id}
-              className="flex items-center gap-3 px-4 py-2.5 text-sm hover:bg-accent/30 transition-colors"
+              className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-accent/30 transition-colors"
             >
-              <span className="text-xs text-muted-foreground tabular-nums w-28 shrink-0">
-                {dayjs(ticket.created_at).format("DD.MM.YY HH:mm")}
-              </span>
-              <span className="font-semibold w-20 shrink-0">
-                #{ticket.order_number}
-              </span>
-              <span className="font-semibold tabular-nums w-32 shrink-0 text-right">
-                {Intl.NumberFormat("ru-RU").format(ticket.order_amount)} сум
-              </span>
-              <span className="text-muted-foreground w-20 shrink-0 text-xs">
-                Детей: {ticket.children_count}
-              </span>
-              <span className="text-muted-foreground truncate min-w-0 flex-1 text-xs">
-                {ticket.terminal_name ?? ""}
-              </span>
-              {ticket.is_used && ticket.used_at && (
-                <span className="text-xs text-muted-foreground whitespace-nowrap hidden md:inline">
-                  исп. {dayjs(ticket.used_at).format("DD.MM HH:mm")}
-                </span>
-              )}
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5 sm:flex-row sm:items-center sm:gap-3">
+                <div className="flex items-center gap-2 sm:w-52 sm:shrink-0">
+                  <span className="font-semibold shrink-0">
+                    #{ticket.order_number}
+                  </span>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {dayjs(ticket.created_at).format("DD.MM.YY HH:mm")}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 min-w-0 sm:gap-3 sm:flex-1">
+                  <span className="font-semibold tabular-nums shrink-0 sm:w-32 sm:text-right">
+                    {Intl.NumberFormat("ru-RU").format(ticket.order_amount)} сум
+                  </span>
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    Детей: {ticket.children_count}
+                  </span>
+                  <span className="text-xs text-muted-foreground truncate min-w-0 hidden md:inline md:flex-1">
+                    {ticket.terminal_name ?? ""}
+                  </span>
+                  {ticket.is_used && ticket.used_at && (
+                    <span className="text-xs text-muted-foreground whitespace-nowrap hidden lg:inline">
+                      исп. {dayjs(ticket.used_at).format("DD.MM HH:mm")}
+                    </span>
+                  )}
+                </div>
+              </div>
               <Badge
                 variant={ticket.is_used ? "destructive" : "default"}
                 className="shrink-0"

--- a/admin/components/layout/playground-layout.tsx
+++ b/admin/components/layout/playground-layout.tsx
@@ -71,11 +71,11 @@ export default function PlaygroundLayout({
         </div>
       </header>
 
-      <main className="flex-1 px-4 py-4 pb-20">
+      <main className="flex-1 px-4 py-4 pb-24">
         {children}
       </main>
 
-      <nav className="fixed bottom-0 left-0 z-50 w-full border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <nav className="fixed inset-x-0 bottom-0 z-50 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 pb-[env(safe-area-inset-bottom)]">
         <div className="grid h-16 max-w-lg mx-auto" style={{ gridTemplateColumns: `repeat(${navItems.length}, 1fr)` }}>
           {navItems.map((item) => {
             const active = isActive(item.href);


### PR DESCRIPTION
- Switch the ticket row to a responsive two-line mobile layout that keeps the order number, time, amount and badge visible on narrow screens, and reveals the terminal/used-at columns only on sm/md/lg. The previous fixed-width columns overflowed the viewport on phones.
- Use inset-x-0 instead of left-0/w-full on the playground bottom nav, add safe-area-inset-bottom padding for iOS home-indicator, and bump main padding to pb-24 so the last row can always clear the fixed nav.