### PR TITLE
fix: fail-closed unknown terminals in playground generate

### DIFF
--- a/backend/src/modules/playground_tickets/controller.ts
+++ b/backend/src/modules/playground_tickets/controller.ts
@@ -49,13 +49,23 @@ export const playgroundTicketsController = new Elysia({
         .where(eq(terminals.id, terminal_id))
         .execute();
 
-      if (terminalRow.length > 0 && !terminalRow[0].playground_enabled) {
+      if (terminalRow.length === 0) {
+        console.log(
+          "[playground-generate] unknown terminal_id:",
+          terminal_id,
+          "token_org:",
+          token.organization_id
+        );
+        set.status = 404;
+        return { message: "Terminal not found" };
+      }
+
+      if (!terminalRow[0].playground_enabled) {
         set.status = 403;
         return { message: "Playground tickets disabled for this terminal" };
       }
 
-      const organization_id =
-        terminalRow[0]?.organization_id ?? token.organization_id;
+      const organization_id = terminalRow[0].organization_id;
 
       const children_count = Math.floor(order_amount / 50000);
 


### PR DESCRIPTION
## Summary
- Previous pass-through behaviour let any terminal_id not found in the `terminals` table silently receive a ticket, bypassing the admin toggle entirely. That explains the report where playground QR kept printing at a branch despite all non-Ko'kcha rows having `playground_enabled=false` — iiko was sending a terminal_id that did not match any managers row, so the generator was falling through.
- Make behaviour predictable: unknown terminal_id → 404, disabled → 403, only a matched + enabled row inserts a ticket. Log the incoming terminal_id on the 404 path so the operator can see exactly what iiko is sending and add/correct the row.

## Test plan
- [ ] Deploy, restart `office_api`
- [ ] Postman: POST `/api/playground_tickets/generate` with enabled terminal (`206fd215...`) → 200 + qr_data
- [ ] Postman: POST with disabled terminal (`3dae1a29...`) → 403
- [ ] Postman: POST with made-up UUID → 404 + `[playground-generate] unknown terminal_id:` line in `office-api-out.log`
- [ ] Real cashier at disabled branch: QR should NOT print; backend log will show the UUID iiko actually sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)