### PR TITLE
fix: guard playground scanner against double-submit

### DIFF
--- a/admin/app/[locale]/admin/playground/scan/page.tsx
+++ b/admin/app/[locale]/admin/playground/scan/page.tsx
@@ -15,9 +15,13 @@ export default function PlaygroundScanPage() {
   const [result, setResult] = useState<ValidationResult | null>(null);
   const [isScanning, setIsScanning] = useState(false);
   const scannerRef = useRef<Html5Qrcode | null>(null);
+  const isProcessingRef = useRef(false);
   const scannerContainerId = "qr-reader";
 
   const handleQrData = useCallback(async (qrData: string) => {
+    if (isProcessingRef.current) return;
+    isProcessingRef.current = true;
+
     if (scannerRef.current?.isScanning) {
       await scannerRef.current.stop();
       setIsScanning(false);
@@ -77,6 +81,7 @@ export default function PlaygroundScanPage() {
 
   const startScanner = useCallback(async () => {
     setResult(null);
+    isProcessingRef.current = false;
     try {
       if (!scannerRef.current) {
         scannerRef.current = new Html5Qrcode(scannerContainerId);


### PR DESCRIPTION
## Summary
- html5-qrcode invokes the decode callback for every frame (~10/s) and \`scanner.stop()\` is async — so several frames slip past the \`isScanning\` guard before stop resolves, each firing its own POST to \`/playground_tickets/validate\`. First request marks used, second sees \`is_used=true\` and returns "already used" — that's the error shown to the cashier on a valid first-time ticket.
- Fix with a synchronous \`isProcessingRef\` set the moment the first callback lands and cleared only when the user restarts the scanner.

## Test plan
- [ ] Deploy \`office_admin\`
- [ ] Generate a fresh QR via kitchen POS, scan with admin scanner
- [ ] Expect "Билет действителен" on first scan, "уже использован" only on second scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)