### PR TITLE
feat: map iiko terminal_id to managers row via terminals.iiko_id

### DIFF
--- a/backend/drizzle/migrations/0005_terminals_iiko_id.sql
+++ b/backend/drizzle/migrations/0005_terminals_iiko_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "terminals" ADD COLUMN IF NOT EXISTS "iiko_id" uuid;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "terminals_iiko_id_unique" ON "terminals" ("iiko_id") WHERE "iiko_id" IS NOT NULL;--> statement-breakpoint
+UPDATE "terminals" SET "iiko_id" = '988d67a1-99c5-431c-94a3-111f49373dfe' WHERE "id" = '206fd215-4d09-497e-aa3a-b4433fe2c547';--> statement-breakpoint
+UPDATE "terminals" SET "iiko_id" = '24448fa6-63e0-46bf-953f-ba24af65e19e' WHERE "id" = '3dae1a29-0a16-4f46-bd25-b309767b1340';--> statement-breakpoint
+UPDATE "terminals" SET "iiko_id" = 'b51063f2-2fa0-459d-8f7c-94b8650dcb0f' WHERE "id" = '0b0c9915-b511-461c-b262-72f59244384a';

--- a/backend/drizzle/migrations/meta/_journal.json
+++ b/backend/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776432732973,
       "tag": "0004_graceful_victor_mancha",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776500000000,
+      "tag": "0005_terminals_iiko_id",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -505,6 +505,7 @@ export const terminals = pgTable("terminals", {
   organization_id: uuid("organization_id").notNull(),
   manager_name: text("manager_name"),
   playground_enabled: boolean("playground_enabled").default(false).notNull(),
+  iiko_id: uuid("iiko_id"),
   created_at: timestamp("created_at", { withTimezone: true, mode: "string" })
     .defaultNow()
     .notNull(),

--- a/backend/src/modules/playground_tickets/controller.ts
+++ b/backend/src/modules/playground_tickets/controller.ts
@@ -1,7 +1,7 @@
 import { ctx } from "@backend/context";
 import { parseFilterFields } from "@backend/lib/parseFilterFields";
 import { playground_tickets, terminals } from "backend/drizzle/schema";
-import { SQLWrapper, sql, and, eq } from "drizzle-orm";
+import { SQLWrapper, sql, and, eq, or } from "drizzle-orm";
 import Elysia, { t } from "elysia";
 
 export const playgroundTicketsController = new Elysia({
@@ -42,11 +42,14 @@ export const playgroundTicketsController = new Elysia({
 
       const terminalRow = await drizzle
         .select({
+          id: terminals.id,
           organization_id: terminals.organization_id,
           playground_enabled: terminals.playground_enabled,
         })
         .from(terminals)
-        .where(eq(terminals.id, terminal_id))
+        .where(
+          or(eq(terminals.id, terminal_id), eq(terminals.iiko_id, terminal_id))
+        )
         .execute();
 
       if (terminalRow.length === 0) {
@@ -65,6 +68,7 @@ export const playgroundTicketsController = new Elysia({
         return { message: "Playground tickets disabled for this terminal" };
       }
 
+      const resolved_terminal_id = terminalRow[0].id;
       const organization_id = terminalRow[0].organization_id;
 
       const children_count = Math.floor(order_amount / 50000);
@@ -77,7 +81,7 @@ export const playgroundTicketsController = new Elysia({
       const inserted = await drizzle
         .insert(playground_tickets)
         .values({
-          terminal_id,
+          terminal_id: resolved_terminal_id,
           organization_id,
           order_number,
           order_amount,


### PR DESCRIPTION
## Summary
- Each branch can have two UUIDs: a historical one in managers terminals (admin toggle + joins) and a different one iiko actually sends. Fail-closed enforcement broke branches where those diverge — Ko'kcha regressed after the previous fix.
- Add optional terminals.iiko_id column. Generate looks up by id OR iiko_id. Insert stores managers-side terminals.id so existing join in list controller keeps working.
- Backfill 3 known mappings (Les Ko'kcha, Les Markaz-5, Chopar Ko'kcha).

## Test plan
- [ ] Apply migration 0005 on prod DB
- [ ] Restart office_api
- [ ] Cashier at Les Ko'kcha (iiko sends 988d67a1...) -> QR should print
- [ ] Cashier at Les Markaz-5 (iiko sends 24448fa6...) -> no QR
- [ ] Cashier at Chopar Ko'kcha (iiko sends b51063f2...) -> no QR

🤖 Generated with [Claude Code](https://claude.com/claude-code)