### PR TITLE
feat: default to today and sort playground tickets by newest

### DIFF
--- a/admin/app/[locale]/admin/playground/list/data-table.tsx
+++ b/admin/app/[locale]/admin/playground/list/data-table.tsx
@@ -16,6 +16,11 @@ import dayjs from "dayjs";
 import { DateRangeFilter } from "@admin/components/filters/date-range-filter/date-range-filter";
 import { useDateRangeState } from "@admin/components/filters/date-range-filter/date-range-state.hook";
 
+const todayRange = (() => {
+  const now = new Date();
+  return { from: now, to: now };
+})();
+
 type PlaygroundTicket = {
   id: string;
   terminal_name: string | null;
@@ -31,7 +36,7 @@ export function DataTable() {
   const [pageIndex, setPageIndex] = useState(0);
   const pageSize = 20;
   const [statusFilter, setStatusFilter] = useState<string>("all");
-  const { dateRange } = useDateRangeState();
+  const { dateRange } = useDateRangeState(todayRange);
 
   const filters = useMemo(() => {
     const res: any[] = [];

--- a/admin/components/filters/date-range-filter/date-range-state.hook.tsx
+++ b/admin/components/filters/date-range-filter/date-range-state.hook.tsx
@@ -44,12 +44,12 @@ const lastYear = {
   to: endOfYear(subYears(today, 1)),
 };
 
-export function useDateRangeState() {
+export function useDateRangeState(defaultRange?: DateRange) {
 
   const [dateRange, setDateRange] = useQueryState<DateRange | undefined>(
     "date",
     {
-      defaultValue: last30Days,
+      defaultValue: defaultRange ?? last30Days,
       parse: (value) => {
         const [from, to] = value.split(",");
         return { from: new Date(from), to: new Date(to) };

--- a/backend/src/modules/playground_tickets/controller.ts
+++ b/backend/src/modules/playground_tickets/controller.ts
@@ -1,7 +1,7 @@
 import { ctx } from "@backend/context";
 import { parseFilterFields } from "@backend/lib/parseFilterFields";
 import { playground_tickets, terminals } from "backend/drizzle/schema";
-import { SQLWrapper, sql, and, eq, or } from "drizzle-orm";
+import { SQLWrapper, sql, and, eq, or, desc } from "drizzle-orm";
 import Elysia, { t } from "elysia";
 
 export const playgroundTicketsController = new Elysia({
@@ -254,6 +254,7 @@ export const playgroundTicketsController = new Elysia({
         .from(playground_tickets)
         .leftJoin(terminals, eq(playground_tickets.terminal_id, terminals.id))
         .where(and(...whereClause))
+        .orderBy(desc(playground_tickets.created_at))
         .limit(+limit)
         .offset(+offset)
         .execute();


### PR DESCRIPTION
- Backend: ORDER BY created_at DESC on list endpoint
- Admin: useDateRangeState accepts optional defaultRange
- Playground list page opens on today instead of last 30 days

🤖 Generated with Claude Code