### PR TITLE
refactor: use credentials table for iiko_id mapping

### DIFF
--- a/backend/drizzle/migrations/0006_drop_terminals_iiko_id.sql
+++ b/backend/drizzle/migrations/0006_drop_terminals_iiko_id.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "terminals_iiko_id_unique";--> statement-breakpoint
+ALTER TABLE "terminals" DROP COLUMN IF EXISTS "iiko_id";

--- a/backend/drizzle/migrations/meta/_journal.json
+++ b/backend/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776500000000,
       "tag": "0005_terminals_iiko_id",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776600000000,
+      "tag": "0006_drop_terminals_iiko_id",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/schema.ts
+++ b/backend/drizzle/schema.ts
@@ -505,7 +505,6 @@ export const terminals = pgTable("terminals", {
   organization_id: uuid("organization_id").notNull(),
   manager_name: text("manager_name"),
   playground_enabled: boolean("playground_enabled").default(false).notNull(),
-  iiko_id: uuid("iiko_id"),
   created_at: timestamp("created_at", { withTimezone: true, mode: "string" })
     .defaultNow()
     .notNull(),

--- a/backend/src/modules/playground_tickets/controller.ts
+++ b/backend/src/modules/playground_tickets/controller.ts
@@ -1,6 +1,6 @@
 import { ctx } from "@backend/context";
 import { parseFilterFields } from "@backend/lib/parseFilterFields";
-import { playground_tickets, terminals } from "backend/drizzle/schema";
+import { playground_tickets, terminals, credentials } from "backend/drizzle/schema";
 import { SQLWrapper, sql, and, eq, or, desc } from "drizzle-orm";
 import Elysia, { t } from "elysia";
 
@@ -40,6 +40,9 @@ export const playgroundTicketsController = new Elysia({
         return { message: "Token not active" };
       }
 
+      // Resolve terminal: plugin may send either the managers-side terminals.id
+      // or iiko's GetHostTerminalsGroup().Id (stored in credentials with
+      // model='terminals', type='iiko_id'). Match both paths in one query.
       const terminalRow = await drizzle
         .select({
           id: terminals.id,
@@ -47,9 +50,21 @@ export const playgroundTicketsController = new Elysia({
           playground_enabled: terminals.playground_enabled,
         })
         .from(terminals)
-        .where(
-          or(eq(terminals.id, terminal_id), eq(terminals.iiko_id, terminal_id))
+        .leftJoin(
+          credentials,
+          and(
+            eq(credentials.model, "terminals"),
+            eq(credentials.type, "iiko_id"),
+            eq(credentials.model_id, sql`${terminals.id}::text`)
+          )
         )
+        .where(
+          or(
+            eq(sql`${terminals.id}::text`, terminal_id),
+            eq(credentials.key, terminal_id)
+          )
+        )
+        .limit(1)
         .execute();
 
       if (terminalRow.length === 0) {


### PR DESCRIPTION
sales_plans already resolves iiko_id via credentials (model='terminals', type='iiko_id'). Reuse that instead of the terminals.iiko_id column added in PR #39 — credentials already has 30+ mappings that were unused.

Generate endpoint now matches terminal_id via terminals.id OR credentials.key; iiko_id column dropped.

🤖 Generated with Claude Code